### PR TITLE
Add federated recommender

### DIFF
--- a/shfl/data_distribution/data_distribution_explicit.py
+++ b/shfl/data_distribution/data_distribution_explicit.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from shfl.data_distribution.data_distribution import DataDistribution
+from shfl.private import LabeledData, FederatedData
 
 
 class ExplicitDataDistribution(DataDistribution):
@@ -10,6 +11,34 @@ class ExplicitDataDistribution(DataDistribution):
 
     In this data distribution we assume that the first column in the data determines the node it belongs to.
     """
+
+    def get_federated_data(self, percent=100, *args, **kwargs):
+        """
+        Method that splits the whole data between the established number of nodes.
+
+        # Arguments:
+            num_nodes: Number of nodes to create
+            percent: Percent of the data (between 0 and 100) to be distributed (default is 100)
+
+        # Returns:
+              * **federated_data, test_data, test_label**
+        """
+
+        train_data, train_label = self._database.train
+        test_data, test_label = self._database.test
+
+        federated_train_data, federated_train_label = self.make_data_federated(train_data,
+                                                                               train_label,
+                                                                               percent,
+                                                                               *args, **kwargs)
+
+        federated_data = FederatedData()
+        num_nodes = len(federated_train_label)
+        for node in range(num_nodes):
+            node_data = LabeledData(federated_train_data[node], federated_train_label[node])
+            federated_data.add_data_node(node_data, federated_train_data[node][0, 0])
+
+        return federated_data, test_data, test_label
 
     def make_data_federated(self, data, labels, percent, *args, **kwargs):
         """

--- a/shfl/data_distribution/data_distribution_explicit.py
+++ b/shfl/data_distribution/data_distribution_explicit.py
@@ -15,6 +15,7 @@ class ExplicitDataDistribution(DataDistribution):
     def get_federated_data(self, percent=100, *args, **kwargs):
         """
         Method that splits the whole data between the established number of nodes.
+        It assigns the client Id of the data as the FederatedDataNode identifier.
 
         # Arguments:
             num_nodes: Number of nodes to create

--- a/shfl/federated_government/distributed_government.py
+++ b/shfl/federated_government/distributed_government.py
@@ -1,0 +1,87 @@
+import abc
+
+
+class DistributedGovernment(abc.ABC):
+    """
+    Abstract class for distributed government
+
+    # Arguments:
+       model_builder_server: Function that returns the server's trainable model (see: [Model](../model))
+       model_builder_node: Function that returns the node's trainable model
+       federated_data: Federated data to use.
+       (see: [FederatedData](../private/federated_operation/#federateddata-class))
+       aggregator: Federated aggregator function (see: [Federated Aggregator](../federated_aggregator))
+       model_param_access: Policy to access model's parameters, by default non-protected
+       (see: [DataAccessDefinition](../private/data/#dataaccessdefinition-class))
+
+    """
+
+    def __init__(self, model_builder_server, model_builder_node, federated_data, aggregator, model_params_access=None):
+        self._federated_data = federated_data
+        self._model = model_builder_server()
+        self._aggregator = aggregator
+        for data_node in federated_data:
+            data_node.model = model_builder_node()
+            if model_params_access is not None:
+                data_node.configure_model_params_access(model_params_access)
+
+    @property
+    def global_model(self):
+        return self._model
+
+    @abc.abstractmethod
+    def evaluate_global_model(self, data_test, label_test):
+        """
+        Abstract method that evaluates the performance of the global model.
+
+        # Arguments:
+            test_data: test dataset
+            test_label: corresponding labels to test dataset
+        """
+
+    @abc.abstractmethod
+    def deploy_central_model(self):
+        """
+        Abstract method to deploy the global learning model to each client (node) in the simulation.
+        """
+
+    @abc.abstractmethod
+    def evaluate_clients(self, data_test, label_test):
+        """
+        Method that must implement every federated government extending this class.
+
+        It evaluates the local learning models over global test dataset.
+
+        # Arguments:
+            test_data: test dataset
+            test_label: corresponding labels to test dataset
+        """
+
+    def train_all_clients(self):
+        """
+        Train all the clients
+        """
+        for data_node in self._federated_data:
+            data_node.train_model()
+
+    def aggregate_weights(self):
+        """
+        Collect the weights from all data nodes in the server model and aggregate them
+        """
+        weights = []
+        for data_node in self._federated_data:
+            weights.append(data_node.query_model_params())
+
+        aggregated_weights = self._aggregator.aggregate_weights(weights)
+
+        return aggregated_weights
+
+    @abc.abstractmethod
+    def run_rounds(self, test_data, test_label):
+        """
+        Run one more round beginning in the actual state testing in test data and federated_local_test.
+
+        # Arguments:
+            test_data: Test data for evaluation between rounds
+            test_label: Test label for evaluation between rounds
+        """

--- a/shfl/federated_government/federated_recommender.py
+++ b/shfl/federated_government/federated_recommender.py
@@ -1,0 +1,88 @@
+import abc
+import numpy as np
+
+from shfl.federated_government.distributed_government import DistributedGovernment
+
+
+class FederatedRecommender(DistributedGovernment):
+    """
+    Class used to represent the central class FederatedRecommender.
+
+    # Arguments:
+       model_builder: Function that return a trainable model (see: [Model](../model))
+       federated_data: Federated data to use.
+       (see: [FederatedData](../private/federated_operation/#federateddata-class))
+       aggregator: Federated aggregator function (see: [Federated Aggregator](../federated_aggregator))
+       model_param_access: Policy to access model's parameters, by default non-protected
+       (see: [DataAccessDefinition](../private/data/#dataaccessdefinition-class))
+
+    # Properties:
+        global_model: Return the global model.
+
+    The training and test data are arrays such that the first column denotes the clientId to which that data belongs.
+    Every model in a node must contain the clientId property.
+    """
+
+    def __init__(self, model_builder_server, model_builder_node, federated_data, aggregator, model_params_access=None):
+        super().__init__(model_builder_server, model_builder_node, federated_data, aggregator, model_params_access)
+
+    def evaluate_global_model(self, data_test, label_test):
+        """
+        Method that evaluates the performance of the global model.
+
+        # Arguments:
+            test_data: test dataset. The first column corresponds to the clientId.
+            test_label: corresponding labels to test dataset
+        """
+        evaluations, _ = self.evaluate_clients(data_test, label_test)
+        return self.evaluate_global_model_recommender(data_test, label_test, evaluations)
+
+    @abc.abstractmethod
+    def evaluate_global_model_recommender(self, data_test, label_test, evaluations):
+        """
+        Method that evaluates the performance of the global model using the evaluation of each client.
+
+        # Arguments:
+            test_data: test dataset. The first column corresponds to the clientId.
+            test_label: corresponding labels to test dataset.
+            evaluations: dictionary containing the evaluation of the clients.
+        """
+
+    @abc.abstractmethod
+    def deploy_central_model(self):
+        """
+        Abstract method to deploy the global learning model to each client (node) in the simulation.
+        """
+
+    def evaluate_clients(self, data_test, label_test):
+        """
+        Method that must implement every federated government extending this class.
+
+        It evaluates the local learning models over global test dataset.
+
+        # Arguments:
+            test_data: test dataset. The first column corresponds to the clientId.
+            test_label: corresponding labels to test dataset.
+
+        # Returns:
+            evaluations: a dictionary containing the evaluations of the clients.
+            evaluations: a dictionary containing the local evaluations of the clients.
+        """
+        evaluations = dict.fromkeys(np.unique(data_test[:, 0]))
+        local_evaluations = dict.fromkeys(np.unique(data_test[:, 0]))
+        for data_node in self._federated_data:
+            client_id = data_node.federated_data_identifier
+            data_client = data_test[data_test[:, 0] == client_id]
+            label_client = label_test[data_test[:, 0] == client_id]
+            evaluations[client_id], local_evaluations[client_id] = data_node.evaluate(data_client, label_client)
+        return evaluations, local_evaluations
+
+    @abc.abstractmethod
+    def run_rounds(self, test_data, test_label):
+        """
+        Run one more round beginning in the actual state testing in test data and federated_local_test.
+
+        # Arguments:
+            test_data: Test data for evaluation between rounds. The first column corresponds to the clientId.
+            test_label: Test label for evaluation between rounds
+        """

--- a/shfl/federated_government/federated_recommender_simple.py
+++ b/shfl/federated_government/federated_recommender_simple.py
@@ -1,0 +1,58 @@
+import numpy as np
+
+from shfl.federated_government.federated_recommender import FederatedRecommender
+
+
+class SimpleFederatedRecommender(FederatedRecommender):
+    """
+    Class used to represent the central class FederatedRecommender.
+
+    # Arguments:
+       model_builder: Function that return a trainable model (see: [Model](../model))
+       federated_data: Federated data to use.
+       (see: [FederatedData](../private/federated_operation/#federateddata-class))
+       aggregator: Federated aggregator function (see: [Federated Aggregator](../federated_aggregator))
+       model_param_access: Policy to access model's parameters, by default non-protected
+       (see: [DataAccessDefinition](../private/data/#dataaccessdefinition-class))
+
+    # Properties:
+        global_model: Return the global model.
+
+    The training and test data are arrays such that the first column denotes the clientId to which that data belongs.
+    Every model in a node must contain the clientId property.
+    """
+
+    def __init__(self, model_builder, federated_data):
+        super().__init__(model_builder, model_builder, federated_data, aggregator=None, model_params_access=None)
+
+    def deploy_central_model(self):
+        for data_node in self._federated_data:
+            data_node.set_model_params(self._model.get_model_params())
+
+    def evaluate_global_model_recommender(self, data_test, label_test, evaluations):
+        """
+        Method that evaluates the performance of the global model using the evaluation of each client.
+
+        # Arguments:
+            test_data: test dataset. The first column corresponds to the clientId.
+            test_label: corresponding labels to test dataset.
+            evaluations: dictionary containing the evaluation of the clients.
+        """
+        num_test = 0
+        squared_error = 0
+        for client in np.unique(data_test[:, 0]):
+            eva_tmp = evaluations[client]
+            num_test += len(data_test[data_test[:, 0] == client])
+            squared_error += eva_tmp ** 2 * len(data_test[data_test[:, 0] == client])
+        rmse = np.sqrt(squared_error / num_test)
+        print("RMSE in the test set: {:.2f}".format(rmse))
+
+    def run_rounds(self, test_data, test_label):
+        """
+        # Arguments:
+            test_data: Test data for evaluation between rounds
+            test_label: Test label for evaluation between rounds
+        """
+        self.deploy_central_model()
+        self.train_all_clients()
+        self.evaluate_global_model(test_data, test_label)

--- a/shfl/federated_government/federated_recommender_simple.py
+++ b/shfl/federated_government/federated_recommender_simple.py
@@ -46,6 +46,7 @@ class SimpleFederatedRecommender(FederatedRecommender):
             squared_error += eva_tmp ** 2 * len(data_test[data_test[:, 0] == client])
         rmse = np.sqrt(squared_error / num_test)
         print("RMSE in the test set: {:.2f}".format(rmse))
+        return rmse
 
     def run_rounds(self, test_data, test_label):
         """

--- a/shfl/model/recommender.py
+++ b/shfl/model/recommender.py
@@ -4,36 +4,6 @@ import numpy as np
 from shfl.model.model import TrainableModel
 
 
-def _check_data(data):
-    """
-    Method that checks if the data corresponds to a single user
-
-    # Arguments:
-        data: array with data
-    """
-    number_of_clients = len(np.unique(data[:, 0]))
-
-    if number_of_clients > 1:
-        raise AssertionError("Data need to correspond to a single user. "
-                             "Current data includes {} clients".format(number_of_clients))
-
-
-def _check_data_labels(data, labels):
-    """
-    Method that checks if the data and the labels have matching dimensions
-
-    # Arguments:
-        data: array with data
-    """
-    rows_in_data = data.shape[0]
-    number_of_labels = len(labels)
-
-    if rows_in_data != number_of_labels:
-        raise AssertionError("Data and labels do not have matching dimensions. "
-                             "Current data has {} rows and there are {} labels".format(rows_in_data,
-                                                                                       number_of_labels))
-
-
 class Recommender(TrainableModel):
     """
     Abstract class for recommender systems using \
@@ -45,7 +15,44 @@ class Recommender(TrainableModel):
     """
 
     def __init__(self):
-        self._clientId = None
+        super().__init__()
+        self._client_id = None
+
+    @staticmethod
+    def _check_data(data):
+        """
+        Method that checks if the data corresponds to a single user
+
+        # Arguments:
+            data: array with data
+        """
+        number_of_clients = len(np.unique(data[:, 0]))
+
+        if number_of_clients > 1:
+            raise AssertionError("Data need to correspond to a single user. "
+                                 "Current data includes {} clients".format(number_of_clients))
+
+    @staticmethod
+    def _check_data_labels(data, labels):
+        """
+        Method that checks if the data and the labels have matching dimensions
+
+        # Arguments:
+            data: array with data
+        """
+        rows_in_data = data.shape[0]
+        number_of_labels = len(labels)
+
+        if rows_in_data != number_of_labels:
+            raise AssertionError("Data and labels do not have matching dimensions. "
+                                 "Current data has {} rows and there are {} labels".format(rows_in_data,
+                                                                                           number_of_labels))
+
+    def _restrict_data(self, data):
+        return data[data[:, 0] == self._client_id]
+
+    def _restrict_labels(self, data, labels):
+        return labels[data[:, 0] == self._client_id]
 
     def train(self, data, labels):
         """
@@ -55,9 +62,12 @@ class Recommender(TrainableModel):
             data: Data to train the model
             labels: Label for each train element
         """
-        _check_data(data)
-        _check_data_labels(data, labels)
-        self._clientId = data[0, 0]
+        self._client_id = data[0, 0]
+        # data_client = self._restrict_data(data)
+        # labels_client = self._restrict_labels(data, labels)
+        self._check_data(data)
+        self._check_data_labels(data, labels)
+
         self.train_recommender(data, labels)
 
     @abc.abstractmethod
@@ -80,7 +90,8 @@ class Recommender(TrainableModel):
         # Returns:
             predictions: Matrix with predictions for data
         """
-        _check_data(data)
+        # data_client = self._restrict_data(data)
+        self._check_data(data)
         return self.predict_recommender(data)
 
     @abc.abstractmethod
@@ -104,8 +115,10 @@ class Recommender(TrainableModel):
             data: Data to be evaluated. Only includes the data of this client
             labels: True values of data
         """
-        _check_data(data)
-        _check_data_labels(data, labels)
+        # data_client = self._restrict_data(data)
+        # labels_client = self._restrict_labels(data, labels)
+        self._check_data(data)
+        self._check_data_labels(data, labels)
         return self.evaluate_recommender(data, labels)
 
     @abc.abstractmethod
@@ -145,8 +158,10 @@ class Recommender(TrainableModel):
             data: Data to be evaluated. Only includes the data of this client
             labels: True values of data
         """
-        _check_data(data)
-        _check_data_labels(data, labels)
+        # data_client = self._restrict_data(data)
+        # labels_client = self._restrict_labels(data, labels)
+        self._check_data(data)
+        self._check_data_labels(data, labels)
         return self.performance_recommender(data, labels)
 
     @abc.abstractmethod

--- a/shfl/model/recommender.py
+++ b/shfl/model/recommender.py
@@ -48,12 +48,6 @@ class Recommender(TrainableModel):
                                  "Current data has {} rows and there are {} labels".format(rows_in_data,
                                                                                            number_of_labels))
 
-    def _restrict_data(self, data):
-        return data[data[:, 0] == self._client_id]
-
-    def _restrict_labels(self, data, labels):
-        return labels[data[:, 0] == self._client_id]
-
     def train(self, data, labels):
         """
         Method that trains the model. This method checks that the data belongs to a single client.
@@ -63,8 +57,6 @@ class Recommender(TrainableModel):
             labels: Label for each train element
         """
         self._client_id = data[0, 0]
-        # data_client = self._restrict_data(data)
-        # labels_client = self._restrict_labels(data, labels)
         self._check_data(data)
         self._check_data_labels(data, labels)
 
@@ -90,7 +82,6 @@ class Recommender(TrainableModel):
         # Returns:
             predictions: Matrix with predictions for data
         """
-        # data_client = self._restrict_data(data)
         self._check_data(data)
         return self.predict_recommender(data)
 
@@ -115,8 +106,6 @@ class Recommender(TrainableModel):
             data: Data to be evaluated. Only includes the data of this client
             labels: True values of data
         """
-        # data_client = self._restrict_data(data)
-        # labels_client = self._restrict_labels(data, labels)
         self._check_data(data)
         self._check_data_labels(data, labels)
         return self.evaluate_recommender(data, labels)
@@ -158,8 +147,6 @@ class Recommender(TrainableModel):
             data: Data to be evaluated. Only includes the data of this client
             labels: True values of data
         """
-        # data_client = self._restrict_data(data)
-        # labels_client = self._restrict_labels(data, labels)
         self._check_data(data)
         self._check_data_labels(data, labels)
         return self.performance_recommender(data, labels)

--- a/shfl/private/federated_operation.py
+++ b/shfl/private/federated_operation.py
@@ -33,6 +33,10 @@ class FederatedDataNode(DataNode):
         super().__init__()
         self._federated_data_identifier = federated_data_identifier
 
+    @property
+    def federated_data_identifier(self):
+        return self._federated_data_identifier
+
     def query(self, private_property=None, **kwargs):
         """
         Queries private data previously configured. If the access didn't configured this method will raise exception
@@ -135,14 +139,16 @@ class FederatedData:
     def __iter__(self):
         return iter(self._data_nodes)
 
-    def add_data_node(self, data):
+    def add_data_node(self, data, identifier=None):
         """
         This method adds a new node containing data to the federated data
 
         # Arguments:
             data: Data to add to this node
         """
-        node = FederatedDataNode(str(id(self)))
+        if identifier is None:
+            identifier = str(id(self))
+        node = FederatedDataNode(identifier)
         node.set_private_data(data)
         self._data_nodes.append(node)
 

--- a/test/data_distribution/test_data_distribution_explicit.py
+++ b/test/data_distribution/test_data_distribution_explicit.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from shfl.data_base.data_base import DataBase
 from shfl.data_distribution.data_distribution_explicit import ExplicitDataDistribution
+from shfl.private import UnprotectedAccess
 
 
 class TestDataBase(DataBase):
@@ -44,3 +45,20 @@ def test_make_data_federated():
     assert len(federated_data) == len(np.unique(train_data[:, 0]))
     assert (np.sort(all_data.ravel()) == np.sort(train_data[idx, ].ravel())).all()
     assert (np.sort(all_label, 0) == np.sort(train_label[idx], 0)).all()
+
+
+def test_get_data_federated():
+    data = TestDataBase()
+    data.load_data()
+    data_distribution = ExplicitDataDistribution(data)
+
+    federated_data, test_data, test_label = data_distribution.get_federated_data()
+
+    data_access_definition = UnprotectedAccess()
+    federated_data.configure_data_access(data_access_definition)
+    group_query = federated_data.query()
+
+    for i in range(len(group_query)):
+        identifier = federated_data[i].federated_data_identifier
+        identifier_data = group_query[i].data[0, 0]
+        assert identifier == identifier_data

--- a/test/federated_government/test_federated_government.py
+++ b/test/federated_government/test_federated_government.py
@@ -18,7 +18,7 @@ class TestFederatedGovernment(FederatedGovernment):
     def aggregate_weights(self):
         pass
 
-    def run_rounds(self, n, test_data, test_label):
+    def run_rounds(self, test_data, test_label, n=1, *args, **kwargs):
         pass
 
 
@@ -152,9 +152,7 @@ def test_aggregate_weights():
     weights = np.random.rand(64, 32)
     fdg._aggregator.aggregate_weights.return_value = weights
 
-    fdg.aggregate_weights()
-
-    fdg._model.set_model_params.assert_called_once_with(weights)
+    np.testing.assert_array_equal(fdg.aggregate_weights(), weights)
 
 
 def test_federated_government_private_data():
@@ -172,6 +170,7 @@ def test_federated_government_private_data():
 
     assert isinstance(la.global_model, model_builder)
     assert aggregator.id == la._aggregator.id
+
 
 def test_run_rounds():
     model_builder = Mock
@@ -191,7 +190,7 @@ def test_run_rounds():
     fdg.aggregate_weights = Mock()
     fdg.evaluate_global_model = Mock()
 
-    fdg.run_rounds(1, test_data, test_labels)
+    fdg.run_rounds(test_data, test_labels, 1)
 
     fdg.deploy_central_model.assert_called_once()
     fdg.train_all_clients.assert_called_once()
@@ -220,7 +219,7 @@ def test_run_rounds_local_tests():
     fdg.aggregate_weights = Mock()
     fdg.evaluate_global_model = Mock()
 
-    fdg.run_rounds(1, test_data, test_labels)
+    fdg.run_rounds(test_data, test_labels, 1)
 
     fdg.deploy_central_model.assert_called_once()
     fdg.train_all_clients.assert_called_once()

--- a/test/federated_government/test_federated_recommender_simple.py
+++ b/test/federated_government/test_federated_recommender_simple.py
@@ -1,0 +1,91 @@
+import numpy as np
+from unittest.mock import Mock
+
+from shfl.federated_government.federated_recommender_simple import SimpleFederatedRecommender
+from shfl.data_base.data_base import DataBase
+from shfl.data_distribution.data_distribution_explicit import ExplicitDataDistribution
+from shfl.private.data import UnprotectedAccess
+from shfl.private.federated_operation import split_train_test
+
+
+class TestDataBase(DataBase):
+    def __init__(self):
+        super(TestDataBase, self).__init__()
+
+    def load_data(self):
+        self._train_data = np.array([[2, 3, 51],
+                                     [1, 34, 6],
+                                     [22, 33, 7],
+                                     [22, 13, 65],
+                                     [1, 3, 15]])
+        self._test_data = np.array([[2, 2, 1],
+                                    [22, 0, 4],
+                                    [1, 1, 5]])
+        self._train_labels = np.array([3, 2, 5, 6, 7])
+        self._test_labels = np.array([4, 7, 2])
+
+
+def test_deploy_central_model():
+    model_builder = Mock
+    database = TestDataBase()
+    database.load_data()
+    db = ExplicitDataDistribution(database)
+
+    federated_data, test_data, test_labels = db.get_federated_data()
+
+    fdr = SimpleFederatedRecommender(model_builder, federated_data)
+    array_params = np.random.rand(30)
+    fdr._model.get_model_params.return_value = array_params
+
+    fdr.deploy_central_model()
+
+    for node in fdr._federated_data:
+        node._model.set_model_params.assert_called_once()
+
+
+def test_evaluate_global_model():
+    model_builder = Mock
+    database = TestDataBase()
+    database.load_data()
+    db = ExplicitDataDistribution(database)
+
+    federated_data, test_data, test_labels = db.get_federated_data()
+
+    fdr = SimpleFederatedRecommender(model_builder, federated_data)
+
+    for node in fdr._federated_data:
+        node.evaluate = Mock()
+        node.evaluate.return_value = [np.array(2), None]
+
+    rmse = fdr.evaluate_global_model(test_data, test_labels)
+    assert rmse == 2
+
+
+def test_run_rounds():
+    model_builder = Mock
+    database = TestDataBase()
+    database.load_data()
+    db = ExplicitDataDistribution(database)
+
+    federated_data, test_data, test_labels = db.get_federated_data()
+
+    fdr = SimpleFederatedRecommender(model_builder, federated_data)
+
+    for node in fdr._federated_data:
+        node.evaluate = Mock()
+        node.evaluate.return_value = [np.array(2), None]
+
+    fdr.deploy_central_model()
+    fdr.train_all_clients()
+    fdr.evaluate_global_model(test_data, test_labels)
+
+    fdr.deploy_central_model = Mock()
+    fdr.train_all_clients = Mock()
+    fdr.evaluate_global_model = Mock()
+
+    fdr.run_rounds(test_data, test_labels)
+
+    fdr.deploy_central_model.assert_called_once()
+    fdr.train_all_clients.assert_called_once()
+    fdr.evaluate_global_model.assert_called_once_with(test_data, test_labels)
+

--- a/test/model/test_content_based_recommender.py
+++ b/test/model/test_content_based_recommender.py
@@ -13,7 +13,7 @@ def test_content_based_recommender():
     content_based_recommender = ContentBasedRecommender(df_items)
     df_items.index.name = "itemid"
 
-    assert content_based_recommender._clientId is None
+    assert content_based_recommender._client_id is None
     assert content_based_recommender._mu is None
     assert content_based_recommender._profile is None
     pd.testing.assert_frame_equal(content_based_recommender._df_items, df_items)
@@ -45,7 +45,7 @@ def test_train():
     df_data = pd.DataFrame(data, columns=["userid", "itemid"])
     df = df_data.join(df_items, on="itemid").drop(["userid", "itemid"], axis=1)
 
-    assert content_based_recommender._clientId == data[0, 0]
+    assert content_based_recommender._client_id == data[0, 0]
     assert content_based_recommender._mu == np.mean(labels)
     np.testing.assert_equal(content_based_recommender._profile,
                             df.multiply(labels - np.mean(labels), axis=0).mean().values)

--- a/test/model/test_mean_recommender.py
+++ b/test/model/test_mean_recommender.py
@@ -7,7 +7,7 @@ from shfl.model.mean_recommender import MeanRecommender
 def test_mean_recommender():
     mean_recommender = MeanRecommender()
 
-    assert mean_recommender._clientId is None
+    assert mean_recommender._client_id is None
 
 
 def test_train():
@@ -21,7 +21,7 @@ def test_train():
     mean_recommender = MeanRecommender()
     mean_recommender.train(data, labels)
 
-    assert mean_recommender._clientId == data[0, 0]
+    assert mean_recommender._client_id == data[0, 0]
     assert mean_recommender._mu == np.mean(labels)
 
 

--- a/test/private/test_federated_operation.py
+++ b/test/private/test_federated_operation.py
@@ -117,3 +117,10 @@ def test_evaluate(mock_super_local_evaluate, mock_super_evaluate):
     mock_super_local_evaluate.assert_called_once_with(identifier)
 
 
+def test_get_identifier():
+    data = np.random.rand(15)
+    test = np.random.rand(5)
+
+    identifier = 'id'
+    fdn = FederatedDataNode(identifier)
+    assert fdn.federated_data_identifier == identifier


### PR DESCRIPTION
I added the federated recommender class. I had to change the structure of the classes.

This also forced me to change the class ExplicitDataDistribution. Right now, when each FederatedDataNode is created, it sets the client id in the data as the identifier of the object.

I didn't change the documentation. I will do it if you agree with the changes.